### PR TITLE
Update go package version

### DIFF
--- a/images/amd64.dockerfile
+++ b/images/amd64.dockerfile
@@ -17,7 +17,7 @@ RUN apk --no-cache -U add libbpf=0.4.0-r0
 FROM bpf as builder
 COPY . /usr/src/afxdp_k8s_plugins
 WORKDIR /usr/src/afxdp_k8s_plugins
-RUN apk add --no-cache go=1.16.10-r0 make=4.3-r0 libbsd-dev=0.11.3-r0 libbpf-dev=0.4.0-r0 \
+RUN apk add --no-cache go=1.16.15-r0 make=4.3-r0 libbsd-dev=0.11.3-r0 libbpf-dev=0.4.0-r0 \
       && make builddp
 
 FROM bpf


### PR DESCRIPTION
The following error occurs because the pinned version of the go package is out of date.

```
Step 6/11 : RUN apk add --no-cache go=1.16.10-r0 make=4.3-r0 libbsd-dev=0.11.3-r0 libbpf-dev=0.4.0-r0       && make builddp
 ---> Running in 826cc441d937
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
ERROR: unable to select packages:
  go-1.16.15-r0:
    breaks: world[go=1.16.10-r0]
```
