### PR TITLE
Bug fix for kernel v6.0.0

### DIFF
--- a/internal/cni/cni.go
+++ b/internal/cni/cni.go
@@ -376,7 +376,7 @@ func CmdDel(args *skel.CmdArgs) error {
 		}
 		if isSf {
 			logging.Debugf("cmdDel(): deleting subfunction %s", cfg.Device)
-			portIndex, err := netHandler.GetCdqPortIndex(cfg.Device)
+			_, portIndex, err := netHandler.GetCdqPortInfo(cfg.Device)
 			if err != nil {
 				logging.Errorf("cmdDel(): error getting port index of device %s: %v", cfg.Device, err)
 			} else {

--- a/internal/networking/device.go
+++ b/internal/networking/device.go
@@ -157,7 +157,7 @@ func (d *Device) ActivateCdqSubfunction() error {
 
 	sfNum := strings.Split(d.name, "sf")[1]
 
-	err = d.netHandler.CreateCdqSubfunction(pci, sfNum)
+	err = d.netHandler.CreateCdqSubfunction(d.primary.name, pci, sfNum)
 	if err != nil {
 		return fmt.Errorf("Error creating CDQ subfunction %s: %v", d.name, err)
 	}

--- a/internal/networking/networking.go
+++ b/internal/networking/networking.go
@@ -55,11 +55,11 @@ type Handler interface {
 	NetDevExists(device string) (bool, error)
 	GetDeviceFromFile(deviceName string, filepath string) (*Device, error)
 	WriteDeviceFile(device *Device, filepath string) error
-	CreateCdqSubfunction(parentPci string, sfnum string) error                   // see subfunction package
+	CreateCdqSubfunction(device string, parentPci string, sfnum string) error    // see subfunction package
 	DeleteCdqSubfunction(portIndex string) error                                 // see subfunction package
 	IsCdqSubfunction(name string) (bool, error)                                  // see subfunction package
 	NumAvailableCdqSubfunctions(interfaceName string) (int, error)               // see subfunction package
-	GetCdqPortIndex(netdev string) (string, error)                               // see subfucntions package
+	GetCdqPortInfo(netdev string) (string, string, error)                        // see subfucntions package
 	SetEthtool(ethtoolCmd []string, interfaceName string, ipResult string) error // see ethtool.go
 	DeleteEthtool(interfaceName string) error                                    // see ethtool.go
 	IsPhysicalPort(name string) (bool, error)
@@ -352,8 +352,8 @@ func (r *handler) IsPhysicalPort(name string) (bool, error) {
 /*
 Wrapper for Subfunctions API calls
 */
-func (r *handler) CreateCdqSubfunction(parentPci string, sfnum string) error {
-	err := subfunctions.CreateCdqSubfunction(parentPci, sfnum)
+func (r *handler) CreateCdqSubfunction(device string, parentPci string, sfnum string) error {
+	err := subfunctions.CreateCdqSubfunction(device, parentPci, sfnum)
 	return err
 }
 
@@ -384,9 +384,9 @@ func (r *handler) NumAvailableCdqSubfunctions(interfaceName string) (int, error)
 /*
 Wrapper for Subfunctions API calls
 */
-func (r *handler) GetCdqPortIndex(netdev string) (string, error) {
-	result, err := subfunctions.GetCdqPortIndex(netdev)
-	return result, err
+func (r *handler) GetCdqPortInfo(netdev string) (string, string, error) {
+	portNumber, portIndex, err := subfunctions.GetCdqPortInfo(netdev)
+	return portNumber, portIndex, err
 }
 
 /*

--- a/internal/networking/networking_fake.go
+++ b/internal/networking/networking_fake.go
@@ -128,11 +128,11 @@ func (r *fakeHandler) NetDevExists(device string) (bool, error) {
 }
 
 /*
-CreateCdqSubfunction takes the PCI address of a port and a subfunction number
+CreateCdqSubfunction takes the device name, PCI address of a port and a subfunction number
 It creates that subfunction on top of that port and activates it
 In this fake handler it does nothing
 */
-func (r *fakeHandler) CreateCdqSubfunction(parentPci string, sfnum string) error {
+func (r *fakeHandler) CreateCdqSubfunction(device string, parentPci string, sfnum string) error {
 	return nil
 }
 
@@ -153,13 +153,13 @@ func (r *fakeHandler) IsCdqSubfunction(name string) (bool, error) {
 }
 
 /*
-GetCdqPortIndex takes a netdev name and returns the port index (pci/sfnum)
+GetCdqPortInfo takes a netdev name and returns the port number and index (pci/sfnum)
 Note this function only works on physical devices and CDQ subfunctions
 Other netdevs will return a "device not found by devlink" error
 In this fake handler it currently returns an empty string
 */
-func (r *fakeHandler) GetCdqPortIndex(netdev string) (string, error) {
-	return "", nil
+func (r *fakeHandler) GetCdqPortInfo(netdev string) (string, string, error) {
+	return "", "", nil
 }
 
 /*


### PR DESCRIPTION
Executing device plugin on kernel version 6.0.0 requires the correct physical port number of primary devices when creating CDQ subfunctions using devlink API.

On previous kernel versions, the CreateCdqSubfunction() function assumes the PF number is 0. For kenrel v6.0.0, the correct port number must be assigned. The GetCDQPortIndex() function is now changed to GetCdqPortInfo(), which returns both the port index and number.