### PR TITLE
Update CDQ with dynamic pfnum

### DIFF
--- a/internal/networking/device.go
+++ b/internal/networking/device.go
@@ -152,12 +152,17 @@ func (d *Device) ActivateCdqSubfunction() error {
 
 	pci, err := d.primary.Pci()
 	if err != nil {
-		return fmt.Errorf("error getting primary device PCI while activating subfunction %s", d.name)
+		return fmt.Errorf("error getting primary device PCI while activating subfunction %s: %v", d.name, err)
+	}
+
+	pfnum, err := d.netHandler.GetCdqPfnum(d.primary.name)
+	if err != nil {
+		return fmt.Errorf("error getting primary device pfnum while activating subfunction %s: %v", d.name, err)
 	}
 
 	sfNum := strings.Split(d.name, "sf")[1]
 
-	err = d.netHandler.CreateCdqSubfunction(pci, sfNum)
+	err = d.netHandler.CreateCdqSubfunction(pci, pfnum, sfNum)
 	if err != nil {
 		return fmt.Errorf("error creating CDQ subfunction %s: %v", d.name, err)
 	}

--- a/internal/networking/networking.go
+++ b/internal/networking/networking.go
@@ -55,11 +55,12 @@ type Handler interface {
 	NetDevExists(device string) (bool, error)
 	GetDeviceFromFile(deviceName string, filepath string) (*Device, error)
 	WriteDeviceFile(device *Device, filepath string) error
-	CreateCdqSubfunction(parentPci string, sfnum string) error                   // see subfunction package
+	CreateCdqSubfunction(parentPci string, pfnum string, sfnum string) error     // see subfunction package
 	DeleteCdqSubfunction(portIndex string) error                                 // see subfunction package
 	IsCdqSubfunction(name string) (bool, error)                                  // see subfunction package
 	NumAvailableCdqSubfunctions(interfaceName string) (int, error)               // see subfunction package
 	GetCdqPortIndex(netdev string) (string, error)                               // see subfucntions package
+	GetCdqPfnum(netdev string) (string, error)                                   // see subfucntions package
 	SetEthtool(ethtoolCmd []string, interfaceName string, ipResult string) error // see ethtool.go
 	DeleteEthtool(interfaceName string) error                                    // see ethtool.go
 	IsPhysicalPort(name string) (bool, error)
@@ -352,8 +353,8 @@ func (r *handler) IsPhysicalPort(name string) (bool, error) {
 /*
 Wrapper for Subfunctions API calls
 */
-func (r *handler) CreateCdqSubfunction(parentPci string, sfnum string) error {
-	err := subfunctions.CreateCdqSubfunction(parentPci, sfnum)
+func (r *handler) CreateCdqSubfunction(parentPci string, pfnum string, sfnum string) error {
+	err := subfunctions.CreateCdqSubfunction(parentPci, pfnum, sfnum)
 	return err
 }
 
@@ -386,6 +387,14 @@ Wrapper for Subfunctions API calls
 */
 func (r *handler) GetCdqPortIndex(netdev string) (string, error) {
 	result, err := subfunctions.GetCdqPortIndex(netdev)
+	return result, err
+}
+
+/*
+Wrapper for Subfunctions API calls
+*/
+func (r *handler) GetCdqPfnum(netdev string) (string, error) {
+	result, err := subfunctions.GetCdqPfnum(netdev)
 	return result, err
 }
 

--- a/internal/networking/networking_fake.go
+++ b/internal/networking/networking_fake.go
@@ -132,7 +132,7 @@ CreateCdqSubfunction takes the PCI address of a port and a subfunction number
 It creates that subfunction on top of that port and activates it
 In this fake handler it does nothing
 */
-func (r *fakeHandler) CreateCdqSubfunction(parentPci string, sfnum string) error {
+func (r *fakeHandler) CreateCdqSubfunction(parentPci string, pfnum string, sfnum string) error {
 	return nil
 }
 
@@ -159,6 +159,16 @@ Other netdevs will return a "device not found by devlink" error
 In this fake handler it currently returns an empty string
 */
 func (r *fakeHandler) GetCdqPortIndex(netdev string) (string, error) {
+	return "", nil
+}
+
+/*
+GetCdqPfnum takes a netdev name and returns the physical port number / pfnum
+Note this function only works on physical devices and CDQ subfunctions
+Other netdevs will return a "device not found by devlink" error
+In this fake handler it currently returns an empty string
+*/
+func (r *fakeHandler) GetCdqPfnum(netdev string) (string, error) {
 	return "", nil
 }
 


### PR DESCRIPTION
More recent versions of CDQ require pfnum rather than simply accepting 0 This patch enables the CDQ code to discover and use the pfnum