### PR TITLE
bpf-map-pinning: fixes a few issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,10 @@ UdsServerDisable is a Boolean configuration. If set to true, devices in this poo
 
 BpfMapPinningEnable is a Boolean configuration. If set to true, will use BPF map pinning instead of a UDS to share an XSK map with a pod. By default, this is set to false. Should set UdsServerDisable to true when using this configuration.
 
+> **_NOTE:_**  When using this setting it's important to adjust the securityContext for the DP Daemonset to `privileged: true` to allow for bidirectional propagation of the volume where the BPF maps are pinned. this will no longer be needed when the DP is integrated with bpfman. An example deamonset configuration is shown in [deamonset-pinning.yaml](./deployments/daemonset-pinning.yaml)
+
+> **_NOTE:_**  If the kernel is <= 5.18, CAP_BPF capability should be added to the container in the Pod.
+
 #### UdsTimeout
 
 UdsTimeout is an integer configuration. This value sets the amount of time, in seconds, that the UDS server will wait while there is no activity on the UDS. When this timeout limit is reached, the UDS server terminates and the UDS is deleted from the filesystem. This can be a useful setting, for example, in scenarios where large batches of pods are created together. Large batches of pods tend to take some time to spin up, so it might be beneficial to have the UDS server sit waiting a little longer for the pod to start. The maximum allowed value is 300 seconds (5 min). The minimum and default value is 30 seconds.

--- a/cmd/deviceplugin/main.go
+++ b/cmd/deviceplugin/main.go
@@ -98,7 +98,7 @@ func main() {
 	}
 	logging.Infof("Host meets requirements")
 
-	//START THE SYNCER SERVER TODO CHECK BPF MAP
+	//Start the syncer server
 	dpCniSyncerServer, err := dpcnisyncerserver.NewSyncerServer()
 	if err != nil {
 		logging.Errorf("Error creating the DpCniSyncerServer")
@@ -143,7 +143,6 @@ func main() {
 			logging.Errorf("Termination error: %v", err)
 		}
 	}
-
 }
 
 func configureLogging(cfg deviceplugin.PluginConfig) error {

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -84,6 +84,7 @@ var (
 	udsPodSock    = "/afxdp.sock"
 
 	/* BPF*/
+	pinMapBaseDir = "/var/run/afxdp_dp/"
 	bpfMapPodPath = "/tmp/afxdp_dp/"
 	xsk_map       = "/xsks_map"
 
@@ -222,6 +223,7 @@ type uds struct {
 }
 
 type bpf struct {
+	PinMapBaseDir string
 	BpfMapPodPath string
 	Xsk_map       string
 }
@@ -349,6 +351,7 @@ func init() {
 	}
 
 	Bpf = bpf{
+		PinMapBaseDir: pinMapBaseDir,
 		BpfMapPodPath: bpfMapPodPath,
 		Xsk_map:       xsk_map,
 	}

--- a/deployments/daemonset-pinning.yaml
+++ b/deployments/daemonset-pinning.yaml
@@ -1,0 +1,113 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: afxdp-dp-config
+  namespace: kube-system
+data:
+  config.json: |
+    {
+       "logLevel":"debug",
+       "logFile":"afxdp-dp.log",
+       "pools":[
+          {
+             "name":"myPool",
+             "mode":"primary",
+             "drivers":[
+                {
+                   "name":"i40e"
+                },
+                {
+                   "name":"ice"
+                }
+             ]
+          }
+       ]
+    }
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: afxdp-device-plugin
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-afxdp-device-plugin
+  namespace: kube-system
+  labels:
+    tier: node
+    app: afxdp
+spec:
+  selector:
+    matchLabels:
+      name: afxdp-device-plugin
+  template:
+    metadata:
+      labels:
+        name: afxdp-device-plugin
+        tier: node
+        app: afxdp
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+      serviceAccountName: afxdp-device-plugin
+      containers:
+        - name: kube-afxdp
+          image: afxdp-device-plugin:latest
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "40Mi"
+            limits:
+              cpu: "1"
+              memory: "200Mi"
+          volumeMounts:
+            - name: unixsock
+              mountPath: /tmp/afxdp_dp/
+            - name: bpfmappinning
+              mountPath: /var/run/afxdp_dp/
+              mountPropagation: Bidirectional
+            - name: devicesock
+              mountPath: /var/lib/kubelet/device-plugins/
+            - name: resources
+              mountPath: /var/lib/kubelet/pod-resources/
+            - name: config-volume
+              mountPath: /afxdp/config
+            - name: log
+              mountPath: /var/log/afxdp-k8s-plugins/
+            - name: cnibin
+              mountPath: /opt/cni/bin/
+      volumes:
+        - name: unixsock
+          hostPath:
+            path: /tmp/afxdp_dp/
+        - name: bpfmappinning
+          hostPath:
+            path: /var/run/afxdp_dp/
+        - name: devicesock
+          hostPath:
+            path: /var/lib/kubelet/device-plugins/
+        - name: resources
+          hostPath:
+            path: /var/lib/kubelet/pod-resources/
+        - name: config-volume
+          configMap:
+            name: afxdp-dp-config
+            items:
+              - key: config.json
+                path: config.json
+        - name: log
+          hostPath:
+            path: /var/log/afxdp-k8s-plugins/
+        - name: cnibin
+          hostPath:
+            path: /opt/cni/bin/

--- a/deployments/daemonset.yml
+++ b/deployments/daemonset.yml
@@ -78,6 +78,8 @@ spec:
           volumeMounts:
             - name: unixsock
               mountPath: /tmp/afxdp_dp/
+            - name: bpfmappinning
+              mountPath: /var/run/afxdp_dp/
             - name: devicesock
               mountPath: /var/lib/kubelet/device-plugins/
             - name: resources
@@ -92,6 +94,9 @@ spec:
         - name: unixsock
           hostPath:
             path: /tmp/afxdp_dp/
+        - name: bpfmappinning
+          hostPath:
+            path: /var/run/afxdp_dp/
         - name: devicesock
           hostPath:
             path: /var/lib/kubelet/device-plugins/

--- a/examples/cndp-0-0.yaml
+++ b/examples/cndp-0-0.yaml
@@ -13,12 +13,11 @@ spec:
       image:  quay.io/mtahhan/cndp-map-pinning:latest
       imagePullPolicy: IfNotPresent
       securityContext:
-        privileged: true
-          #capabilities:
-          #add:
-          #  - NET_RAW
-          #  - IPC_LOCK
-          #  - BPF
+        capabilities:
+          add:
+            - NET_RAW
+            - IPC_LOCK
+            #- BPF                                 # Only needed if Kernel version <= 5.18
       resources:
         requests:
           afxdp/myPool: '1'

--- a/examples/kind-pod-spec.yaml
+++ b/examples/kind-pod-spec.yaml
@@ -17,7 +17,7 @@ spec:
         add:
           - NET_RAW
           - IPC_LOCK
-          - BPF
+          - BPF                                # Only needed if kernel version <= 5.18
     resources:
       requests:
         afxdp/myPool: '1'                      # The resource requested needs to match the device plugin pool name / resource type

--- a/examples/pod-spec.yaml
+++ b/examples/pod-spec.yaml
@@ -12,6 +12,11 @@ spec:
     image: docker-image:latest                 # Specify your docker image here, along with PullPolicy and command
     imagePullPolicy: IfNotPresent
     command: ["tail", "-f", "/dev/null"]
+    # capabilities:                            # Should be configured if using DPDK/CNDP with BPF Map pinning.
+    #     add:
+    #       - NET_RAW
+    #       - IPC_LOCK
+    #       - BPF                             # Only needed if kernel version <= 5.18
     resources:
       requests:
         afxdp/myPool: '1'                      # The resource requested needs to match the device plugin pool name / resource type

--- a/images/amd64.dockerfile
+++ b/images/amd64.dockerfile
@@ -28,13 +28,14 @@ WORKDIR /usr/src/afxdp_k8s_plugins
 RUN apk add --no-cache build-base~=0.5-r3 \
 && apk add --no-cache libbsd-dev~=0.11.7 \
 && apk add --no-cache libxdp-dev~=1.2.10-r0 \
+&& apk add --no-cache libbpf-dev~=1.0.1-r0 \
 && apk add --no-cache llvm15~=15.0.7-r0 \
 && apk add --no-cache clang15~=15.0.7-r0 \
 && make builddp
 
 FROM amd64/alpine:3.18@sha256:25fad2a32ad1f6f510e528448ae1ec69a28ef81916a004d3629874104f8a7f70
 RUN apk --no-cache -U add iproute2-rdma~=6.3.0-r0 acl~=2.3 \
-      && apk add --no-cache libxdp~=1.2.10-r0
+      && apk add --no-cache xdp-tools~=1.2.10-r0
 COPY --from=cnibuilder /usr/src/afxdp_k8s_plugins/bin/afxdp /afxdp/afxdp
 COPY --from=dpbuilder /usr/src/afxdp_k8s_plugins/bin/afxdp-dp /afxdp/afxdp-dp
 COPY --from=dpbuilder /usr/src/afxdp_k8s_plugins/images/entrypoint.sh /afxdp/entrypoint.sh

--- a/internal/bpf/bpfWrapper.h
+++ b/internal/bpf/bpfWrapper.h
@@ -18,8 +18,6 @@
 #define _WRAPPER_H_
 
 int Load_bpf_send_xsk_map(char *ifname);
-int Load_attach_bpf_xdp_pass(char *ifname);
-int Load_bpf_pin_xsk_map(char *ifname, char *pin_path);
 int Configure_busy_poll(int fd, int busy_timeout, int busy_budget);
 int Clean_bpf(char *ifname);
 

--- a/internal/cni/cni.go
+++ b/internal/cni/cni.go
@@ -338,6 +338,14 @@ func CmdDel(args *skel.CmdArgs) error {
 		}
 	}
 
+	if cfg.DPSyncer {
+		logging.Infof("cmdDel(): Asking Device Plugin to delete any BPF maps for %s", cfg.Device)
+		err := dpcnisyncer.DeleteNetDev(cfg.Device)
+		if err != nil {
+			logging.Errorf("cmdDel(): DeleteNetDev from Syncer Server Failed for %s: %v", cfg.Device, err)
+		}
+	}
+
 	if !cfg.SkipUnloadBpf {
 		logging.Infof("cmdDel(): removing BPF program from device")
 		if err := bpfHandler.Cleanbpf(cfg.Device); err != nil {
@@ -362,14 +370,6 @@ func CmdDel(args *skel.CmdArgs) error {
 					logging.Warningf("cmdDel(): failed to remove ethtool filter: %v", err)
 				}
 			}
-		}
-	}
-
-	if cfg.DPSyncer {
-		logging.Infof("cmdDel(): Asking Device Plugin to delete any BPF maps for %s", cfg.Device)
-		err := dpcnisyncer.DeleteNetDev(cfg.Device)
-		if err != nil {
-			logging.Errorf("cmdDel(): DeleteNetDev from Syncer Server Failed for %s: %v", cfg.Device, err)
 		}
 	}
 

--- a/internal/deviceplugin/poolManager.go
+++ b/internal/deviceplugin/poolManager.go
@@ -107,8 +107,8 @@ func (pm *PoolManager) Init(config PoolConfig) error {
 	if pm.BpfMapPinningEnable {
 		var err error
 
-		logging.Infof("Creating new BPF Map manager %s %s", pm.DevicePrefix+"-maps/", pm.UID)
-		pm.Pbm.Manager, pm.Pbm.Path, err = pm.MapManagerFactory.CreateMapManager(pm.DevicePrefix+"-maps/", pm.UID)
+		logging.Infof("Creating new BPF Map manager %s %s", pm.Name, pm.UID)
+		pm.Pbm.Manager, err = pm.MapManagerFactory.CreateMapManager(pm.Name, pm.UID)
 		if err != nil {
 			logging.Errorf("Error new BPF Map manager: %v", err)
 			return err
@@ -138,6 +138,10 @@ func (pm *PoolManager) Terminate() error {
 
 	if pm.DpCniSyncerServer != nil {
 		pm.DpCniSyncerServer.StopGRPCSyncer()
+	}
+
+	if pm.BpfMapPinningEnable {
+		pm.Pbm.Manager.CleanupMapManager()
 	}
 
 	return nil
@@ -251,7 +255,7 @@ func (pm *PoolManager) Allocate(ctx context.Context,
 
 			if pm.BpfMapPinningEnable {
 				logging.Infof("Loading BPF program on device: %s and pinning the map", device.Name())
-				pinPath, err := pm.Pbm.Manager.CreateBPFFS(device.Name(), pm.Pbm.Path)
+				pinPath, err := pm.Pbm.Manager.CreateBPFFS()
 				if err != nil {
 					logging.Errorf("Error Creating the BPFFS: %v", err)
 					return &response, err


### PR DESCRIPTION
* Fixup the bpf map manager path for multiple pools (same as the UDS issue)
* Update the documentation and various specs to reflect configuration changes needed.
* Update the program to pin the xsk map to just use xdp-loader. The previous c implementation had issues and the version of libxdp in the container images is too old for libxdp pinning support. Reverting to bpf (for pinning support) would break the libxdp based program unloading. and would need to implement another BPF variation... 
* Don't return an error from the bpf clean up function when there's no program on the interface.
* Cleanup the dirs created for bpf map managers in /var/run/afxdp_dp

Tested in a physical cluster with multiple pools and resource requests with both CNDP map pinning and soon to be map pinning patches submitted patches to DPDK