### PR TITLE
yamls: update daemonset for pinning

### DIFF
--- a/deployments/daemonset-pinning.yaml
+++ b/deployments/daemonset-pinning.yaml
@@ -12,6 +12,8 @@ data:
           {
              "name":"myPool",
              "mode":"primary",
+             "UdsServerDisable": true,
+             "BpfMapPinningEnable": true,
              "drivers":[
                 {
                    "name":"i40e"

--- a/examples/nad_with_syncer.yaml
+++ b/examples/nad_with_syncer.yaml
@@ -1,4 +1,5 @@
 # WARNING: This is an example definition only. Remove all comments before use.
+# To be used with AF_XDP DP when map pinning is enabled
 
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition

--- a/examples/network-attachment-definition.yaml
+++ b/examples/network-attachment-definition.yaml
@@ -1,4 +1,5 @@
 # WARNING: This is an example definition only. Remove all comments before use.
+# To be used with AF_XDP DP when UDS support is enabled
 
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition


### PR DESCRIPTION
Update the map pinning Deamonset configuration to enable map pinning. Update the NAD definitions to detail when to use/not use the syncer.